### PR TITLE
Replace deprecated format_string functions by FormattableMarkup

### DIFF
--- a/src/Tests/ProfileAccessTest.php
+++ b/src/Tests/ProfileAccessTest.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\profile\Tests;
 
+use Drupal\Component\Render\FormattableMarkup;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\simpletest\WebTestBase;
@@ -141,7 +142,7 @@ class ProfileAccessTest extends WebTestBase {
       "{$field_name}[0][value]" => $value,
     ];
     $this->drupalPostForm("user/$uid/edit/profile/$id/$profile_id", $edit, t('Save'));
-    $this->assertText(format_string('profile has been updated.'));
+    $this->assertText(new FormattableMarkup('profile has been updated.'));
 
     // Verify that the own profile is still not visible on the account page.
     $this->drupalGet("user/$uid");
@@ -163,7 +164,7 @@ class ProfileAccessTest extends WebTestBase {
     $this->drupalGet("user/$uid/edit/profile/$id/$profile_id");
     $this->clickLink(t('Delete'));
     $this->drupalPostForm(NULL, [], t('Delete'));
-    $this->assertRaw(format_string('@label profile deleted.', ['@label' => $this->type->label()]));
+    $this->assertRaw(new FormattableMarkup('@label profile deleted.', ['@label' => $this->type->label()]));
     $this->assertUrl("user/$uid");
 
     // Verify that the profile is gone.

--- a/src/Tests/ProfileAttachTest.php
+++ b/src/Tests/ProfileAttachTest.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\profile\Tests;
 
+use Drupal\Component\Render\FormattableMarkup;
 use Drupal\simpletest\WebTestBase;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\field\Entity\FieldConfig;
@@ -94,12 +95,12 @@ class ProfileAttachTest extends WebTestBase {
       'pass[pass2]' => $pass_raw,
     ];
     $this->drupalPostForm('user/register', $edit, t('Create new account'));
-    $this->assertRaw(format_string('@name field is required.', ['@name' => $this->instance->label]));
+    $this->assertRaw(new FormattableMarkup('@name field is required.', ['@name' => $this->instance->label]));
 
     // Verify that we can register.
     $edit["entity_" . $id . "[$field_name][0][value]"] = $this->randomMachineName();
     $this->drupalPostForm(NULL, $edit, t('Create new account'));
-    $this->assertText(format_string('Registration successful. You are now logged in.'));
+    $this->assertText(new FormattableMarkup('Registration successful. You are now logged in.'));
 
     $new_user = user_load_by_name($name);
     $this->assertTrue($new_user->isActive(), 'New account is active after registration.');

--- a/src/Tests/ProfileTypeCRUDTest.php
+++ b/src/Tests/ProfileTypeCRUDTest.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\profile\Tests;
 
+use Drupal\Component\Render\FormattableMarkup;
 use Drupal\simpletest\WebTestBase;
 use Drupal\Component\Utility\Unicode;
 
@@ -37,7 +38,7 @@ class ProfileTypeCRUDTest extends WebTestBase {
     ];
     $this->drupalPostForm(NULL, $edit, t('Save'));
     $this->assertUrl('admin/config/people/profiles/types');
-    $this->assertRaw(format_string('%label profile type has been created.', ['%label' => $label]));
+    $this->assertRaw(new FormattableMarkup('%label profile type has been created.', ['%label' => $label]));
     $this->assertLinkByHref("admin/config/people/profiles/types/manage/$id");
     $this->assertLinkByHref("admin/config/people/profiles/types/manage/$id/fields");
     $this->assertLinkByHref("admin/config/people/profiles/types/manage/$id/display");
@@ -45,13 +46,13 @@ class ProfileTypeCRUDTest extends WebTestBase {
 
     // Edit the new profile type.
     $this->drupalGet("admin/config/people/profiles/types/manage/$id");
-    $this->assertRaw(format_string('Edit %label profile type', ['%label' => $label]));
+    $this->assertRaw(new FormattableMarkup('Edit %label profile type', ['%label' => $label]));
     $edit = [
       'registration' => 1,
     ];
     $this->drupalPostForm(NULL, $edit, t('Save'));
     $this->assertUrl('admin/config/people/profiles/types');
-    $this->assertRaw(format_string('%label profile type has been updated.', ['%label' => $label]));
+    $this->assertRaw(new FormattableMarkup('%label profile type has been updated.', ['%label' => $label]));
 
     // Add a field to the profile type.
     $this->drupalGet("admin/config/people/profiles/types/manage/$id/fields/add-field");
@@ -71,7 +72,7 @@ class ProfileTypeCRUDTest extends WebTestBase {
         'destinations[0]' => "admin/config/people/profiles/types/manage/$id/fields/add-field",
       ]
     ]);
-    $this->assertRaw(format_string('Saved %label configuration.', ['%label' => $field_label]));
+    $this->assertRaw(new FormattableMarkup('Saved %label configuration.', ['%label' => $field_label]));
 
     // Rename the profile type ID.
     $this->drupalGet("admin/config/people/profiles/types/manage/$id");
@@ -81,7 +82,7 @@ class ProfileTypeCRUDTest extends WebTestBase {
     ];
     $this->drupalPostForm(NULL, $edit, t('Save'));
     $this->assertUrl('admin/config/people/profiles/types');
-    $this->assertRaw(format_string('%label profile type has been updated.', ['%label' => $label]));
+    $this->assertRaw(new FormattableMarkup('%label profile type has been updated.', ['%label' => $label]));
     $this->assertLinkByHref("admin/config/people/profiles/types/manage/$new_id");
     $this->assertNoLinkByHref("admin/config/people/profiles/types/manage/$id");
     $id = $new_id;


### PR DESCRIPTION
format_string() function is deprecated and is replacer by Drupal\Component\Render\FormattableMarkup.
See change records https://www.drupal.org/node/2302363.