### PR TITLE
Issue #2652170 by GoZ: Display profiles in a profile options widget

### DIFF
--- a/css/profile.options.widget.css
+++ b/css/profile.options.widget.css
@@ -1,4 +1,4 @@
-.form-radios {
+.form-radios, .form-checkboxes {
   display: flex;
   align-items: stretch;
   align-content: space-around;

--- a/css/profile.options.widget.css
+++ b/css/profile.options.widget.css
@@ -1,0 +1,33 @@
+.form-radios {
+  display: flex;
+  align-items: stretch;
+  align-content: space-around;
+  flex-flow: row wrap;
+}
+
+fieldset{
+  border: 0;
+}
+.profile-options-widget .form-item {
+  display: flex;
+  align-items: center;
+  border: 1px solid lightgrey;
+  padding: 5px;
+  border-radius: 2px;
+  flex: 1;
+  min-width: 200px;
+  max-width: 400px;
+  margin: 5px;
+}
+
+.profile-options-widget .form-item:hover {
+  border-color: grey;
+}
+
+.profile-options-widget .form-item input {
+  margin: 0 10px;
+}
+
+.profile-options-widget .form-item label {
+  width: 100%;
+}

--- a/profile.libraries.yml
+++ b/profile.libraries.yml
@@ -3,3 +3,8 @@ drupal.profile-items:
   css:
     component:
       css/profile.base.css: {}
+drupal.profile-options-widget:
+  version: VERSION
+  css:
+    component:
+      css/profile.options.widget.css: {}

--- a/src/Plugin/Field/FieldWidget/ProfileOptionsWidget.php
+++ b/src/Plugin/Field/FieldWidget/ProfileOptionsWidget.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\profile\Plugin\Field\FieldWidget\ProfileOptionsWidget.
+ */
+
+namespace Drupal\profile\Plugin\Field\FieldWidget;
+
+use Drupal\Component\Utility\Html;
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Field\Plugin\Field\FieldWidget\OptionsWidgetBase;
+
+/**
+ * Plugin implementation of the 'profile_options' widget.
+ *
+ * @FieldWidget(
+ *   id = "profile_options",
+ *   label = @Translation("Profile Options list"),
+ *   field_types = {
+ *     "entity_reference",
+ *   },
+ *   multiple_values = FALSE
+ * )
+ */
+class ProfileOptionsWidget extends OptionsWidgetBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+    $element = parent::formElement($items, $delta, $element, $form, $form_state);
+
+    $element += array(
+      '#type' => 'radios',
+      '#options' => $this->getOptions($items->getEntity()),
+      '#default_value' => $this->getSelectedOptions($items, $delta),
+      '#multiple' => FALSE,
+      '#attached' => [
+        'library' => [
+          'profile/drupal.profile-options-widget',
+        ],
+      ],
+      '#attributes' => [
+        'class' => [
+          'profile-options-widget'
+        ],
+      ],
+    );
+
+    return $element;
+  }
+
+  /**
+   * Returns the array of options for the widget.
+   *
+   * @param \Drupal\Core\Entity\FieldableEntityInterface $entity
+   *   The entity for which to return options.
+   *
+   * @return array
+   *   The array of options for the widget.
+   */
+  protected function getOptions(FieldableEntityInterface $entity) {
+    if (!isset($this->options)) {
+      $options = [];
+
+      // Limit the settable options for the current user account.
+      $handler_settings = $this->fieldDefinition->getSetting('handler_settings');
+      $view_builder = \Drupal::entityTypeManager()->getViewBuilder('profile');
+      $renderer = \Drupal::service('renderer');
+      foreach ($handler_settings['target_bundles'] as $bundle) {
+        $profiles = \Drupal::entityTypeManager()->getStorage('profile')->loadMultipleByUser(\Drupal::currentUser(), $bundle);
+        foreach ($profiles as $profile) {
+          $renderable = $view_builder->view($profile, 'profile.profile-options-widget');
+          $options[$profile->id()] = $renderer->render($renderable);
+        }
+      }
+
+      // Add an empty option if the widget needs one.
+      if ($empty_label = $this->getEmptyLabel()) {
+        $options = ['_none' => $empty_label] + $options;
+      }
+
+      $module_handler = \Drupal::moduleHandler();
+      $context = array(
+        'fieldDefinition' => $this->fieldDefinition,
+        'entity' => $entity,
+      );
+      $module_handler->alter('options_list', $options, $context);
+
+      array_walk_recursive($options, array($this, 'sanitizeLabel'));
+
+      // Options might be nested ("optgroups"). If the widget does not support
+      // nested options, flatten the list.
+      if (!$this->supportsGroups()) {
+        $options = OptGroup::flattenOptions($options);
+      }
+
+      $this->options = $options;
+    }
+    return $this->options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function sanitizeLabel(&$label) {
+    // Select form inputs allow unencoded HTML entities, but no HTML tags.
+    $label = Html::decodeEntities($label);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function supportsGroups() {
+    return TRUE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEmptyLabel() {
+    // Add a 'none' option for non-required fields, and a 'select a value'
+    // option for required fields that do not come with a value selected.
+    if (!$this->required) {
+      return t('- None -');
+    }
+  }
+
+}

--- a/src/Plugin/Field/FieldWidget/ProfileOptionsWidget.php
+++ b/src/Plugin/Field/FieldWidget/ProfileOptionsWidget.php
@@ -22,7 +22,7 @@ use Drupal\Core\Field\Plugin\Field\FieldWidget\OptionsWidgetBase;
  *   field_types = {
  *     "entity_reference",
  *   },
- *   multiple_values = FALSE
+ *   multiple_values = TRUE
  * )
  */
 class ProfileOptionsWidget extends OptionsWidgetBase {
@@ -32,12 +32,22 @@ class ProfileOptionsWidget extends OptionsWidgetBase {
    */
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
     $element = parent::formElement($items, $delta, $element, $form, $form_state);
+    $multiple = $this->fieldDefinition->getFieldStorageDefinition()->isMultiple();
+    $values = $items->getValue();
+    if ($multiple) {
+      $default_value = array_column($values, 'target_id');
+      $type = 'checkboxes';
+    }
+    else {
+      $default_value = !empty($values) ? $values[0]['target_id'] : NULL;
+      $type = 'radios';
+    }
 
     $element += array(
-      '#type' => 'radios',
+      '#type' => $type,
       '#options' => $this->getOptions($items->getEntity()),
-      '#default_value' => $this->getSelectedOptions($items, $delta),
-      '#multiple' => FALSE,
+      '#default_value' => $default_value,
+      '#multiple' => $multiple,
       '#attached' => [
         'library' => [
           'profile/drupal.profile-options-widget',

--- a/src/Plugin/Field/FieldWidget/ProfileOptionsWidget.php
+++ b/src/Plugin/Field/FieldWidget/ProfileOptionsWidget.php
@@ -90,8 +90,6 @@ class ProfileOptionsWidget extends OptionsWidgetBase {
       );
       $module_handler->alter('options_list', $options, $context);
 
-      array_walk_recursive($options, array($this, 'sanitizeLabel'));
-
       // Options might be nested ("optgroups"). If the widget does not support
       // nested options, flatten the list.
       if (!$this->supportsGroups()) {
@@ -101,14 +99,6 @@ class ProfileOptionsWidget extends OptionsWidgetBase {
       $this->options = $options;
     }
     return $this->options;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  protected function sanitizeLabel(&$label) {
-    // Select form inputs allow unencoded HTML entities, but no HTML tags.
-    $label = Html::decodeEntities($label);
   }
 
   /**

--- a/src/ProfileViewBuilder.php
+++ b/src/ProfileViewBuilder.php
@@ -9,6 +9,7 @@ namespace Drupal\profile;
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityViewBuilder;
+use Drupal\Core\Render\Element;
 
 /**
  * Render controller for profile entities.
@@ -22,6 +23,25 @@ class ProfileViewBuilder extends EntityViewBuilder {
     $defaults = parent::getBuildDefaults($entity, $view_mode);
     $defaults['#theme'] = 'profile';
     return $defaults;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildComponents(array &$build, array $entities, array $displays, $view_mode) {
+    parent::buildComponents($build, $entities, $displays, $view_mode);
+
+    // Fake view mode user by profile-options-widget to hide labels.
+    if ($view_mode == 'profile.profile-options-widget') {
+      // Remove labels from display
+      foreach ($build as &$display_build) {
+        foreach (Element::children($display_build) as $field_name) {
+          if (isset($display_build[$field_name]['#label_display'])) {
+            $display_build[$field_name]['#label_display'] = 'hidden';
+          }
+        }
+      }
+    }
   }
 
 }


### PR DESCRIPTION
Once this widget will be commited, we will need to update core.entity_form_display.commerce_order.default.default.yml in commerce project to replace
```yml
content:
  billing_profile:
    type: options_select
```

by 

```yml
content:
  billing_profile:
    type: profile_options
```

See issue for summary : https://www.drupal.org/node/2652170